### PR TITLE
Strip correct prefix when cbuild

### DIFF
--- a/.github/workflows/build-and-verify.yml
+++ b/.github/workflows/build-and-verify.yml
@@ -291,6 +291,5 @@ jobs:
         with:
           token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
           files: '${{ needs.configure-ci.outputs.working-dir }}/**/cover.out'
-          strip-prefix: github.com/open-cmsis-pack/${{ inputs.program }}
+          strip-prefix: ${{ inputs.program == 'cbuild' && 'github.com/Open-CMSIS-Pack/cbuild/v2' || format('github.com/Open-CMSIS-Pack/{0}', inputs.program) }}
           skip-errors: false
-          validate: true


### PR DESCRIPTION
## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
