### PR TITLE
Replaced the container-based action invocation with a runner-native 

### DIFF
--- a/.github/workflows/build-and-verify.yml
+++ b/.github/workflows/build-and-verify.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           go-version-file: ${{ inputs.go-version-file }}
           check-latest: true
+          cache: false
 
       - name: Lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/.github/workflows/build-and-verify.yml
+++ b/.github/workflows/build-and-verify.yml
@@ -95,10 +95,13 @@ jobs:
         run: make format-check
         working-directory: ${{ needs.configure-ci.outputs.working-dir }}
 
+      - name: Install gosec
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
+
       - name: Gosec Security Scanner
-        uses: securego/gosec@4a3bd8af174872c778439083ded7adbf3747e770 # v2.26.1
-        with:
-          args: '-severity high -exclude-dir=testdata -exclude=*_test.go ${{ needs.configure-ci.outputs.working-dir }}/...'
+        working-directory: ${{ needs.configure-ci.outputs.working-dir }}
+        run: |
+          "$(go env GOPATH)/bin/gosec" -severity high -exclude-dir=testdata -exclude=*_test.go ./...
 
       - name: Vulnerability Scan
         uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,3 +1,3 @@
 module github.com/open-cmsis-pack/sample
 
-go 1.26
+go 1.26.3

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,3 @@
 module github.com/open-cmsis-pack/sample
 
-go 1.21
-require (
-  github.com/stretchr/testify v1.9.4
-)
+go 1.26


### PR DESCRIPTION
## Changes
- Updated the reusable workflow implementation so gosec runs using the same Go installed by setup-go (1.26.3), instead of the container-provided 1.26.0 local toolchain

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
